### PR TITLE
Change default UI overlay width

### DIFF
--- a/HaloCEVR/Game.cpp
+++ b/HaloCEVR/Game.cpp
@@ -761,7 +761,7 @@ void Game::SetupConfigs()
 	c_UIOverlayDistance = config.RegisterFloat("UIOverlayDistance", "Distance in metres in front of the HMD to display the UI", 15.0f);
 	c_UIOverlayScale = config.RegisterFloat("UIOverlayScale", "Width of the UI overlay in metres", 10.0f);
 	c_UIOverlayCurvature = config.RegisterFloat("UIOverlayCurvature", "Curvature of the UI Overlay, on a scale of 0 to 1", 0.1f);
-	c_UIOverlayWidth = config.RegisterInt("UIOverlayWidth", "Width of the UI overlay in pixels", 600);
+	c_UIOverlayWidth = config.RegisterInt("UIOverlayWidth", "Width of the UI overlay in pixels", 800);
 	c_UIOverlayHeight = config.RegisterInt("UIOverlayHeight", "Height of the UI overlay in pixels", 600);
 	// Control settings
 	c_LeftHanded = config.RegisterBool("LeftHanded", "Make the left hand the dominant hand. Does not affect bindings, change these in the SteamVR overlay", false);


### PR DESCRIPTION
Using 800x600 for the UI overlay seems to fix the overlay crosshair being squished by default. I also noticed some other UI elements were squished as well. (At least, it avoids the bug when the user does not change the config file.) Chimera doesn't seem to handle narrower aspect ratios than 4:3 for the HUD. 
It also looks a bit more natural than the square HUD to me, but that's subjective. 